### PR TITLE
Form children can accept function

### DIFF
--- a/src/components/form-component.js
+++ b/src/components/form-component.js
@@ -30,7 +30,10 @@ const propTypes = {
   formValue: PropTypes.object,
   onSubmit: PropTypes.func,
   dispatch: PropTypes.func,
-  children: PropTypes.node,
+  children: PropTypes.oneOfType([
+    PropTypes.func,
+    PropTypes.node,
+  ]),
   store: PropTypes.shape({
     subscribe: PropTypes.func,
     dispatch: PropTypes.func,


### PR DESCRIPTION
I was looking for a way to use global form state in my custom form component
Digging through the sources I found, that `Form`'s children can be a function and it worked!
However, React complains, that `children` must be a `node`. Here's a fix for that